### PR TITLE
fix #21: handle case where no roles are set

### DIFF
--- a/application/pages/admin/UserPage.php
+++ b/application/pages/admin/UserPage.php
@@ -68,7 +68,7 @@ class UserPage extends PageFrame
                 }
                 break;
             case 'roles';
-                $roles = array_keys(set_value('roles'));
+                $roles = array_keys(set_value('roles', []));
 
                 $success = $this->ci->LoginRole->setRolesForLoginId($loginId, $roles);
                 if ($success) {


### PR DESCRIPTION
Field is not populated when no roles are selected, hence it falls back on the default value. Now explicitly setting this to the empty array, as the previously default empty string was not supported.