### PR TITLE
🐳 Build a proxy image with baked in static files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Ignore everything by default
+**/*
+
+# Include the Dockerfile 
+!Dockerfile
+
+# Include application specific files
+!system/
+!application/
+
+# Include Node package files
+!package.json
+!package-lock.json
+
+# Include static files
+!public/
+!manifest.webmanifest
+!robots.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,19 +16,19 @@ services:
         - "8083:3306"
 
     webserver:
-      image: nginx:alpine
+      build: 
+        dockerfile: docker/nginx/Dockerfile
+        context: .
       container_name: lisa-webserver
-      working_dir: /application
       volumes:
           - ${PWD}/:/application/
           - ${PWD}/docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
       ports:
-       - "8080:80"
+       - "8080:8080"
 
     php-fpm:
       build: docker/php-fpm
       container_name: lisa-php-fpm
-      working_dir: /application
       volumes:
         - ${PWD}:/application
         - ${PWD}/docker/php-fpm/php-ini-overrides.ini:/etc/php/7.3/fpm/conf.d/99-overrides.ini

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,18 @@
+# Get all node dependencies
+FROM node:12 as node-builder
+
+WORKDIR /application
+
+COPY package.json package-lock.json ./
+
+RUN npm install --only=prod
+
+# Add all static files to our NGINX image
+FROM nginx:alpine
+
+WORKDIR /application
+
+COPY --from=node-builder /application/node_modules/ ./
+COPY public/ manifest.webmanifest robots.txt ./
+
+EXPOSE 8080

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80 default;
+    listen 8080 default;
 
     client_max_body_size 108M;
 

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -8,3 +8,5 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get -y --no-install-recommends install  php7.3-mysql \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+WORKDIR /application

--- a/docker/php-fpm/php-ini-overrides.ini
+++ b/docker/php-fpm/php-ini-overrides.ini
@@ -1,2 +1,3 @@
 upload_max_filesize = 100M
 post_max_size = 108M
+security.limit_extensions = 


### PR DESCRIPTION
Previously the NGINX proxy got it's static files mounted in. This changes it by using a multi-stage Dockerfile, which firsts pulls in all Node dependencies and then creating an image based on nginx with all static files baked in.