### PR TITLE
Fix for users without transaction

### DIFF
--- a/application/models/User_Transaction.php
+++ b/application/models/User_Transaction.php
@@ -65,11 +65,16 @@ class User_Transaction extends ModelFrame
 
     public function getLatestForSubjectId($subjectId, $limit = 1)
     {
-        return $this->db
+        $result = $this->db
             ->where(Transaction::FIELD_SUBJECT_ID . '=' . $subjectId)
             ->order_by(Transaction::FIELD_TIME, 'DESC')
             ->limit($limit)
             ->get(Transaction::name())
             ->row_array()[self::FIELD_TIME];
+
+        if ($result == null) {
+		    $result == '2000-01-01 00:00:00';
+		}
+        return $result;
     }
 }

--- a/application/models/User_Transaction.php
+++ b/application/models/User_Transaction.php
@@ -73,8 +73,8 @@ class User_Transaction extends ModelFrame
             ->row_array()[self::FIELD_TIME];
 
         if ($result == null) {
-		    $result == '2000-01-01 00:00:00';
-		}
+            $result == '2000-01-01 00:00:00';
+        }
         return $result;
     }
 }


### PR DESCRIPTION
Well, that was faster then I hoped. After Koen pushed into production we came across a bug where the loopup for the transactions where null if someone hasn't used LISA yet. This fix is tested with the database from production and should fix it.