### PR TITLE
fix: Updates the copyright notice of this application to mention it's from 2018 till 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Adriaan Knapen
+Copyright (c) 2018-2025 Adriaan Knapen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/application/language/dutch/admin/application_lang.php
+++ b/application/language/dutch/admin/application_lang.php
@@ -7,7 +7,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 $lang['admin_application_name'] = 'Jouw beheerspaneel naam hier';
 $lang['admin_application_title'] = 'Jouw beheerspaneel titel hier';
-$lang['copyright'] = '2018, <a style="color:#fff" href="https://aknapen.nl">Adriaan Knapen</a>';
+$lang['copyright'] = '2018-2025, <a style="color:#fff" href="https://aknapen.nl">Adriaan Knapen</a>';
 
 // Side menu
 $lang['application_menu_dashboard'] = 'Dashboard';

--- a/application/language/dutch/default/application_lang.php
+++ b/application/language/dutch/default/application_lang.php
@@ -6,7 +6,7 @@
 
 $lang['application_name'] = 'Jouw naam hier';
 $lang['application_title'] = 'Jouw titel hier';
-$lang['copyright'] = '2020, <a style="color:#fff" href="https://aknapen.nl">Adriaan Knapen</a>';
+$lang['copyright'] = '2018-2025, <a style="color:#fff" href="https://aknapen.nl">Adriaan Knapen</a>';
 
 
 $lang['default_page_header_title'] = 'Welkom';

--- a/application/language/english/admin/application_lang.php
+++ b/application/language/english/admin/application_lang.php
@@ -7,7 +7,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 $lang['application_name'] = 'Admin panel name placeholder';
 $lang['application_title'] = 'Admin panel title placeholder';
-$lang['copyright'] = '2018, <a style="color:#fff" href="https://aknapen.nl">Adriaan Knapen</a>';
+$lang['copyright'] = '2018-2025, <a style="color:#fff" href="https://aknapen.nl">Adriaan Knapen</a>';
 
 // Side menu
 $lang['application_menu_dashboard'] = 'Dashboard';

--- a/application/language/english/default/application_lang.php
+++ b/application/language/english/default/application_lang.php
@@ -7,7 +7,7 @@
 $lang['application_name'] = 'Name placeholder';
 $lang['application_version'] = 'v1.0-beta';
 $lang['application_title'] = 'Title placeholder';
-$lang['copyright'] = '2020, <a style="color:#fff" href="https://aknapen.nl">Adriaan Knapen</a>';
+$lang['copyright'] = '2018-2025, <a style="color:#fff" href="https://aknapen.nl">Adriaan Knapen</a>';
 
 $lang['default_page_header_title'] = 'Welcome';
 $lang['default_page_header_body'] = 'This is your new homepage!';


### PR DESCRIPTION
Update the copyright notice in the application to mention it's from 2018 to 2025.

* Update the copyright notice in `application/language/dutch/admin/application_lang.php` to "2018-2025".
* Update the copyright notice in `application/language/dutch/default/application_lang.php` to "2018-2025".
* Update the copyright notice in `application/language/english/admin/application_lang.php` to "2018-2025".
* Update the copyright notice in `application/language/english/default/application_lang.php` to "2018-2025".
* Update the copyright notice in `LICENSE` to "2018-2025".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Addono/LISA/pull/63?shareId=8ce8e491-07c7-428b-bdfb-a8704655333f).